### PR TITLE
Consume blanks before checking options.

### DIFF
--- a/entry.c
+++ b/entry.c
@@ -249,6 +249,11 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 			goto eof;
 		}
 
+		/* Need to have consumed blanks before checking for options
+		 * below. */
+		Skip_Blanks(ch, file)
+		unget_char(ch, file);
+		
 		pw = getpwnam(username);
 		if (pw == NULL) {
 			ecode = e_username;


### PR DESCRIPTION
Fixes issue as described in https://github.com/freebsd/freebsd-src/pull/456 (consume spaces before checking for '-' char in option processing.)