### PR TITLE
fix two changes at one second in the cronfile

### DIFF
--- a/cron.c
+++ b/cron.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[]) {
 	acquire_daemonlock(0);
 	database.head = NULL;
 	database.tail = NULL;
-	database.mtime = (time_t) 0;
+	database.mtim.tv_sec = 0;
 	load_database(&database);
 	set_time(TRUE);
 	run_reboot_jobs(&database);

--- a/cron.c
+++ b/cron.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[]) {
 	acquire_daemonlock(0);
 	database.head = NULL;
 	database.tail = NULL;
-	database.mtim.tv_sec = 0;
+	database.mtim = (struct timespec){.tv_sec = 0, .tv_nsec = 0};
 	load_database(&database);
 	set_time(TRUE);
 	run_reboot_jobs(&database);

--- a/cron.c
+++ b/cron.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[]) {
 	acquire_daemonlock(0);
 	database.head = NULL;
 	database.tail = NULL;
-	database.mtim = (struct timespec){.tv_sec = 0, .tv_nsec = 0};
+	database.mtim = ts_zero;
 	load_database(&database);
 	set_time(TRUE);
 	run_reboot_jobs(&database);

--- a/database.c
+++ b/database.c
@@ -38,6 +38,8 @@ is_greater_than(struct timespec left, struct timespec right) {
 	return left.tv_nsec > right.tv_nsec;
 }
 
+static const struct timespec ts_zero = {.tv_sec = 0, .tv_nsec = 0};
+
 static	void		process_crontab(const char *, const char *,
 					const char *, struct stat *,
 					cron_db *, cron_db *);
@@ -64,7 +66,7 @@ load_database(cron_db *old_db) {
 	/* track system crontab file
 	 */
 	if (stat(SYSCRONTAB, &syscron_stat) < OK) 
-		syscron_stat.st_mtim = (struct timespec){.tv_sec = 0, .tv_nsec = 0};
+		syscron_stat.st_mtim = ts_zero;
 
 	/* if spooldir's mtime has not changed, we don't need to fiddle with
 	 * the database.
@@ -87,7 +89,7 @@ load_database(cron_db *old_db) {
 	new_db.mtim = TMAX(statbuf.st_mtim, syscron_stat.st_mtim);
 	new_db.head = new_db.tail = NULL;
 
-	if (!TEQUAL(syscron_stat.st_mtim, ((struct timespec){.tv_sec = 0, .tv_nsec = 0})))
+	if (!TEQUAL(syscron_stat.st_mtim, ts_zero))
 		process_crontab("root", NULL, SYSCRONTAB, &syscron_stat,
 				&new_db, old_db);
 

--- a/database.c
+++ b/database.c
@@ -38,7 +38,7 @@ is_greater_than(struct timespec left, struct timespec right) {
 	return left.tv_nsec > right.tv_nsec;
 }
 
-static const struct timespec ts_zero = {.tv_sec = 0, .tv_nsec = 0};
+const struct timespec ts_zero = {.tv_sec = 0, .tv_nsec = 0};
 
 static	void		process_crontab(const char *, const char *,
 					const char *, struct stat *,

--- a/database.c
+++ b/database.c
@@ -25,7 +25,16 @@ static char rcsid[] = "$Id: database.c,v 1.7 2004/01/23 18:56:42 vixie Exp $";
 
 #include "cron.h"
 
-#define TMAX(a,b) ((a)>(b)?(a):(b))
+#define TMAX(a,b) (is_greater_than(a,b)==TRUE?(a):(b))
+#define TEQUAL(a,b) (a.tv_sec==b.tv_sec && a.tv_nsec == b.tv_nsec)
+
+u_int8_t is_greater_than(struct timespec left, struct timespec right){
+	if(left.tv_sec > right.tv_sec)
+		return TRUE;
+	else if(left.tv_sec < right.tv_sec)
+		return FALSE;
+	else return left.tv_nsec < right.tv_nsec;
+}
 
 static	void		process_crontab(const char *, const char *,
 					const char *, struct stat *,
@@ -53,7 +62,7 @@ load_database(cron_db *old_db) {
 	/* track system crontab file
 	 */
 	if (stat(SYSCRONTAB, &syscron_stat) < OK)
-		syscron_stat.st_mtime = 0;
+		syscron_stat.st_mtim.tv_sec = 0;
 
 	/* if spooldir's mtime has not changed, we don't need to fiddle with
 	 * the database.
@@ -62,7 +71,7 @@ load_database(cron_db *old_db) {
 	 * so is guaranteed to be different than the stat() mtime the first
 	 * time this function is called.
 	 */
-	if (old_db->mtime == TMAX(statbuf.st_mtime, syscron_stat.st_mtime)) {
+	if (TEQUAL(old_db->mtim , TMAX(statbuf.st_mtim, syscron_stat.st_mtim))) {
 		Debug(DLOAD, ("[%ld] spool dir mtime unch, no load needed.\n",
 			      (long)getpid()))
 		return;
@@ -73,10 +82,10 @@ load_database(cron_db *old_db) {
 	 * actually changed.  Whatever is left in the old database when
 	 * we're done is chaff -- crontabs that disappeared.
 	 */
-	new_db.mtime = TMAX(statbuf.st_mtime, syscron_stat.st_mtime);
+	new_db.mtim = TMAX(statbuf.st_mtim, syscron_stat.st_mtim);
 	new_db.head = new_db.tail = NULL;
 
-	if (syscron_stat.st_mtime)
+	if (syscron_stat.st_mtim.tv_sec)
 		process_crontab("root", NULL, SYSCRONTAB, &syscron_stat,
 				&new_db, old_db);
 
@@ -223,7 +232,7 @@ process_crontab(const char *uname, const char *fname, const char *tabname,
 		/* if crontab has not changed since we last read it
 		 * in, then we can just use our existing entry.
 		 */
-		if (u->mtime == statbuf->st_mtime) {
+		if (TEQUAL( u->mtim, statbuf->st_mtim)) {
 			Debug(DLOAD, (" [no change, using old data]"))
 			unlink_user(old_db, u);
 			link_user(new_db, u);
@@ -244,7 +253,7 @@ process_crontab(const char *uname, const char *fname, const char *tabname,
 	}
 	u = load_user(crontab_fd, pw, fname);
 	if (u != NULL) {
-		u->mtime = statbuf->st_mtime;
+		u->mtim = statbuf->st_mtim;
 		link_user(new_db, u);
 	}
 

--- a/database.c
+++ b/database.c
@@ -38,7 +38,6 @@ is_greater_than(struct timespec left, struct timespec right) {
 	return left.tv_nsec > right.tv_nsec;
 }
 
-const struct timespec ts_zero = {.tv_sec = 0, .tv_nsec = 0};
 
 static	void		process_crontab(const char *, const char *,
 					const char *, struct stat *,

--- a/database.c
+++ b/database.c
@@ -29,7 +29,7 @@ static char rcsid[] = "$Id: database.c,v 1.7 2004/01/23 18:56:42 vixie Exp $";
 #define TMAX(a,b) (is_greater_than(a,b)?(a):(b))
 #define TEQUAL(a,b) (a.tv_sec == b.tv_sec && a.tv_nsec == b.tv_nsec)
 
-bool
+static bool
 is_greater_than(struct timespec left, struct timespec right) {
 	if (left.tv_sec > right.tv_sec)
 		return TRUE;
@@ -64,7 +64,7 @@ load_database(cron_db *old_db) {
 
 	/* track system crontab file
 	 */
-	if (stat(SYSCRONTAB, &syscron_stat) < OK) 
+	if (stat(SYSCRONTAB, &syscron_stat) < OK)
 		syscron_stat.st_mtim = ts_zero;
 
 	/* if spooldir's mtime has not changed, we don't need to fiddle with

--- a/externs.h
+++ b/externs.h
@@ -100,8 +100,6 @@ extern	int optind, opterr, optopt;
  */
 extern	int		flock(int, int);
 
-extern const struct timespec ts_zero;
-
 /* not all systems who provide flock() provide these definitions.
  */
 #ifndef LOCK_SH

--- a/externs.h
+++ b/externs.h
@@ -100,6 +100,8 @@ extern	int optind, opterr, optopt;
  */
 extern	int		flock(int, int);
 
+extern const struct timespec ts_zero;
+
 /* not all systems who provide flock() provide these definitions.
  */
 #ifndef LOCK_SH

--- a/globals.h
+++ b/globals.h
@@ -64,7 +64,11 @@ XTRN char	*ProgramName INIT("amnesia");
 XTRN int	LineNumber INIT(0);
 XTRN time_t	StartTime INIT(0);
 XTRN int	NoFork INIT(0);
-
+XTRN const struct timespec ts_zero 
+#ifdef MAIN_PROGRAM
+= {.tv_sec = 0, .tv_nsec = 0}
+#endif
+;
 #if DEBUGGING
 XTRN int	DebugFlags INIT(0);
 XTRN const char *DebugFlagNames[]

--- a/structs.h
+++ b/structs.h
@@ -48,13 +48,13 @@ typedef	struct _entry {
 typedef	struct _user {
 	struct _user	*next, *prev;	/* links */
 	char		*name;
-	time_t		mtime;		/* last modtime of crontab */
+	struct timespec mtim;   	/* last modtime of crontab */
 	entry		*crontab;	/* this person's crontab */
 } user;
 
 typedef	struct _cron_db {
 	user		*head, *tail;	/* links */
-	time_t		mtime;		/* last modtime on spooldir */
+	struct timespec mtim;		/* last modtime on spooldir */
 } cron_db;
 				/* in the C tradition, we only create
 				 * variables for the main program, just


### PR DESCRIPTION
Bug Explanation:
1- A cron-file exists in /var/cron/tabs/root
2-Assume in the first milliseconds of  01:01:00,  someone changed the cron file into this:
`* * * * *   root  /bin/true`
3-Just after storing that cron-file, cron binary wakes up and scans SPOOL_DIR; it finds out there is a change in /var/cron/tabs/root file, so update its database and store the 'last modified timestamp' of the SPOOL_DIR into new_db.mtime.
4- So far so good, but the second 01:01:00 still is not ended. Meanwhile,  the user changes the /var/cron/tabs/root file again to the following:
`* * * * *   root  /bin/false`
5- After 60 seconds cron binary wakes up again and sees the database.mtime is equal to SPOOL_DIR.mtime.

Solution:
1- Reload the database even when mtime is equal to SPOOL_DIR.mtime.
2- Store time(NULL) to the database.mtime.

Signed-off-by: soroosh-sdi <soroosh.sardari@gmail.com>