### PR TITLE
Implement Day zero in day-of-the-month field

### DIFF
--- a/database.c
+++ b/database.c
@@ -115,7 +115,7 @@ load_database(cron_db *old_db) {
 		if (strlen(dp->d_name) >= sizeof fname)
 			continue;	/* XXX log? */
 		(void) strcpy(fname, dp->d_name);
-		
+
 		if (!glue_strings(tabname, sizeof tabname, SPOOL_DIR,
 				  fname, '/'))
 			continue;	/* XXX log? */

--- a/entry.c
+++ b/entry.c
@@ -192,7 +192,7 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 
 		if (ch == '*')
 			e->flags |= DOM_STAR;
-		ch = get_list(e->dom, FIRST_DOM, LAST_DOM,
+		ch = get_list(e->dom, PREV_LAST_DOM, LAST_DOM,
 			      PPC_NULL, ch, file);
 		if (ch == EOF) {
 			ecode = e_dom;
@@ -253,7 +253,7 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 		 * below. */
 		Skip_Blanks(ch, file)
 		unget_char(ch, file);
-		
+
 		pw = getpwnam(username);
 		if (pw == NULL) {
 			ecode = e_username;
@@ -358,7 +358,7 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 	/* Everything up to the next \n or EOF is part of the command...
 	 * too bad we don't know in advance how long it will be, since we
 	 * need to malloc a string for it... so, we limit it to MAX_COMMAND.
-	 */ 
+	 */
 	ch = get_string(cmd, MAX_COMMAND, file, "\n");
 
 	/* a file without a \n before the EOF is rude, so we'll complain...
@@ -412,7 +412,7 @@ get_list(bitstr_t *bits, int low, int high, const char *names[],
 
 	/* list = range {"," range}
 	 */
-	
+
 	/* clear the bit string, since the default is 'off'.
 	 */
 	bit_nclear(bits, 0, (high-low+1));

--- a/macros.h
+++ b/macros.h
@@ -98,6 +98,7 @@
 
 #define	SECONDS_PER_MINUTE	60
 #define	SECONDS_PER_HOUR	3600
+#define	SECONDS_PER_DAY		86400
 
 #define	FIRST_MINUTE	0
 #define	LAST_MINUTE	59
@@ -107,9 +108,11 @@
 #define	LAST_HOUR	23
 #define	HOUR_COUNT	(LAST_HOUR - FIRST_HOUR + 1)
 
+/* Use 0 to indicate the last day of the previous month */
+#define	PREV_LAST_DOM	0
 #define	FIRST_DOM	1
 #define	LAST_DOM	31
-#define	DOM_COUNT	(LAST_DOM - FIRST_DOM + 1)
+#define	DOM_COUNT	(LAST_DOM - PREV_LAST_DOM + 1)
 
 #define	FIRST_MONTH	1
 #define	LAST_MONTH	12


### PR DESCRIPTION
This patch is an easy implementation of #4, 0 of dom indicate the last day of previous month.

1. make dom bitstr_t 1-based and leave the bit 0 for last day of the previous month.
2. for each virtual second of `find_joibs`, caculate virtual second of the next day by just adding 86400 seconds.
3. for each entry, if the dom of next day is 1 and the 0 bit of dom is set, further check the minute, hour and month fields.