### PR TITLE
fix bug introduced in pull request 16

### DIFF
--- a/entry.c
+++ b/entry.c
@@ -163,8 +163,8 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 				  FIRST_DOM, LAST_DOM, 1);
 			set_range(e->month, FIRST_MONTH, LAST_MONTH,
 				  FIRST_MONTH, LAST_MONTH, 1);
-			set_element(e->dow, FIRST_DOW, LAST_DOW,
-				    FIRST_DOW);
+			set_range(e->dow, FIRST_DOW, LAST_DOW,
+				    FIRST_DOW, LAST_DOW, 1);
 		} else if (!strcmp("hourly", cmd)) {
 			set_element(e->minute, FIRST_MINUTE, LAST_MINUTE,
 				    FIRST_MINUTE);
@@ -174,8 +174,6 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 				  FIRST_DOM, LAST_DOM, 1);
 			set_range(e->month, FIRST_MONTH, LAST_MONTH,
 				  FIRST_MONTH, LAST_MONTH, 1);
-			set_element(e->dow, FIRST_DOW, LAST_DOW,
-				    FIRST_DOW);
 			set_range(e->dow, FIRST_DOW, LAST_DOW,
 				  FIRST_DOW, LAST_DOW, 1);
 			e->flags |= HR_STAR;
@@ -281,7 +279,7 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 		 * below. */
 		Skip_Blanks(ch, file)
 		unget_char(ch, file);
-		
+
 		pw = getpwnam(username);
 		if (pw == NULL) {
 			ecode = e_username;
@@ -386,7 +384,7 @@ load_entry(FILE *file, void (*error_func)(), struct passwd *pw, char **envp) {
 	/* Everything up to the next \n or EOF is part of the command...
 	 * too bad we don't know in advance how long it will be, since we
 	 * need to malloc a string for it... so, we limit it to MAX_COMMAND.
-	 */ 
+	 */
 	ch = get_string(cmd, MAX_COMMAND, file, "\n");
 
 	/* a file without a \n before the EOF is rude, so we'll complain...
@@ -440,7 +438,7 @@ get_list(bitstr_t *bits, int low, int high, const char *names[],
 
 	/* list = range {"," range}
 	 */
-	
+
 	/* clear the bit string, since the default is 'off'.
 	 */
 	bit_nclear(bits, 0, (high-low));


### PR DESCRIPTION
In load_entry, for @daily or @midnight, we should set every bit for the dow bitstr_t, #16 just set FIRST_DOW, which is wrong; for @hourly, the set_element of dow is redundant since set_range set each bit of dow.

I believe these are typos when replacing bit_set/bit_nset using set_element/set_range by mistake, I did't review it carefully, sorry for the inconvenient.